### PR TITLE
got user's plants to populate in garden

### DIFF
--- a/client/src/components/AddPlantBtn.js
+++ b/client/src/components/AddPlantBtn.js
@@ -13,8 +13,7 @@ function AddPlantBtn(props) {
     function onClick () {
         API.addPlant(data).then(res=>{
             console.log(res.data.common_name + " added to your garden!");
-            // we'll need to update user state in order to re-render
-            // the user's plants here as well
+            // we should add a toast or popup to show that the plant was added to the user's garden
         })
         
     };

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -42,6 +42,7 @@ function Navbar(props) {
             // Set results state
             console.log(results.data)
             props.setResults(results.data);
+            props.setIsSearching(true);
           });
         } else {
           props.setResults([]);

--- a/client/src/components/PlantCard.js
+++ b/client/src/components/PlantCard.js
@@ -25,7 +25,7 @@ function PlantCard(props) {
                 <div className="card m-2 p-2" key={props.plant.id} style={{width: "350px"}}>
                     <h3 className="card-title">{displayName}</h3>
                     <img src={img} className="card-img-top" alt={props.plant.scientific_name} style={{height: "350px"}}/>
-                        <AddPlantBtn plant={props.plant} displayName={displayName} user={props.user} img={img}/>
+                        {props.isSearching && <AddPlantBtn plant={props.plant} displayName={displayName} user={props.user} img={img}/>}
                         <MoreInfoBtn />
                 </div>
  

--- a/client/src/pages/Garden.js
+++ b/client/src/pages/Garden.js
@@ -7,30 +7,41 @@ function Garden(props) {
 
      // State and setter for search results
    const [results, setResults] = useState([]);
-   
+   const [isSearching, setIsSearching] = useState(false);
    
    useEffect(() => {
       console.log(props.user.id)
+      // API.searchUserById(props.user.id)
+      //    .then(res => {
+      //       setResults(res.data.Plants)
+      //    })
+      handleGetPlants();
    }, [])
  
-   // function handleGetPlants() {
-   //    API.findByEmail(results => {
-   //       setPlants({ ...plants, savedPlants: results });
-   //   });
+   const handleGetPlants = () => {
+      API.searchUserById(props.user.id)
+      .then(results => {
+         setResults(results.data.Plants);
+         setIsSearching(false);
+     });
+   }
+   
    console.log(results)
    return (
       <div>
          <div className="jumbotron bg-success">
             <h1 className="display-3 text-center">Your Garden</h1>
          </div>
-         <Navbar setResults={setResults} results={results} /> 
+         <Navbar setResults={setResults} results={results} setIsSearching={setIsSearching} /> 
+            {/* we'll want to re-style this button, this is just a placeholder for functionality */}
+            {isSearching && <button onClick={handleGetPlants}>Back to Garden</button>}
          <div id="plant-cards" className="row p-3 mb-5">
         
         {/* trigger a modal with belows results that you can add to the garden */}
 
          {results.map(result => (
                     
-            <PlantCard key={result.id} plant={result} user={props.user.id}/>
+            <PlantCard key={result.id} plant={result} user={props.user.id} isSearching={isSearching} />
                
          ))}
 

--- a/client/src/utils/API.js
+++ b/client/src/utils/API.js
@@ -49,13 +49,17 @@ export default {
     },
 
     // find user by email
-    findByEmail: function (email) {
-      return axios.get()
-    },
+    // findByEmail: function (email) {
+    //   return axios.get()
+    // },
 
     // post request using userData from google
     signInUser: function (userData) {
       return axios.post("/api/user", userData)
+    },
+
+    searchUserById: function (id) {
+      return axios.get("/api/user/" + id)
     }
 
     


### PR DESCRIPTION
The user’s plants now populate the garden page when they first visit.  Then, when searching the search results come up.  Each of the cards only render the “add to garden” button if they’re in the search state.  Otherwise, it just has the (non-functional at this point) more info button.  We also conditionally render a “back to garden” button that comes up if the user is searching for plants.